### PR TITLE
Handle whoamiResponse.Data.Account nil error

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Configuration
 
     $ echo 'token = "YOURTOKENGOESHERE_YESQUOTED"' >> ~/.domasimurc
     
-Get your token by visiting https://dnsimple.com/user and clicking `+ New access token`
+Get your account token by going to `Account -> Automation -> API tokens -> New`
 
 Alternate Configuration
 -----------------------

--- a/cmd/domasimu/main.go
+++ b/cmd/domasimu/main.go
@@ -47,6 +47,11 @@ func main() {
 		fmt.Fprintln(os.Stderr, "could not connect to dnsimple", err)
 		return
 	}
+
+	if whoamiResponse.Data.Account == nil {
+		fmt.Fprintln(os.Stderr, "you need to use account token instead of user token")
+		return
+	}
 	accountID := strconv.FormatInt(whoamiResponse.Data.Account.ID, 10)
 
 	if *list {


### PR DESCRIPTION
I just read dnsimple api document https://developer.dnsimple.com/v2 and it had 2 kind for token,
So if we need to update or create record we need to use account token for that.

This may fix: https://github.com/jrwren/domasimu/issues/4